### PR TITLE
update the unsafe's readPending

### DIFF
--- a/src/main/java/org/xnio/netty/transport/AbstractXnioSocketChannel.java
+++ b/src/main/java/org/xnio/netty/transport/AbstractXnioSocketChannel.java
@@ -368,14 +368,11 @@ abstract class AbstractXnioSocketChannel  extends AbstractChannel implements Soc
     }
 
     protected abstract class AbstractXnioUnsafe extends AbstractUnsafe {
-        private boolean readPending;
+        private boolean readPending = false;
 
-        /*@Override
-        public void beginRead() {
-            // Channel.read() or ChannelHandlerContext.read() was called
+        public void beginRead0() {
             readPending = true;
-            super.beginRead();
-        }*/
+        }
 
         @Override
         protected void flush0() {
@@ -535,6 +532,7 @@ abstract class AbstractXnioSocketChannel  extends AbstractChannel implements Soc
         if (conn == null) {
             return;
         }
+        ((AbstractXnioUnsafe)unsafe()).beginRead0();
         ConduitStreamSourceChannel source = conn.getSourceChannel();
         if (!source.isReadResumed()) {
             source.resumeReads();


### PR DESCRIPTION
Trying to run the WildFly's helloworld-jms quickstart with your updated lib (and Netty 4.1.5.Final and Artemis 1.5.0), the readPending attribute was never set to true and thus the condition in org.xnio.netty.transport.AbstractXnioSocketChannel.ReadListener always lead to remove the readOp